### PR TITLE
Feat: Download Counts On Homepage & Download Page

### DIFF
--- a/download.js
+++ b/download.js
@@ -1,17 +1,11 @@
 import { githubAPIFetch } from "./github-cache.js";
+import { formatDownloadCount } from "./utils.js";
 
 const RELEASE_API_URI = "repos/PasscodesApp/Passcodes/releases";
 
 let allReleases = [];
 let currentFilter = "all";
 let searchQuery = "";
-
-function formatDownloadCount(num) {
-    if (num >= 1_000_000)
-        return (num / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
-    if (num >= 1_000) return (num / 1_000).toFixed(1).replace(/\.0$/, "") + "K";
-    return num.toLocaleString();
-}
 
 document.addEventListener("DOMContentLoaded", init);
 

--- a/download.js
+++ b/download.js
@@ -6,6 +6,13 @@ let allReleases = [];
 let currentFilter = "all";
 let searchQuery = "";
 
+function formatDownloadCount(num) {
+    if (num >= 1_000_000)
+        return (num / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+    if (num >= 1_000) return (num / 1_000).toFixed(1).replace(/\.0$/, "") + "K";
+    return num.toLocaleString();
+}
+
 document.addEventListener("DOMContentLoaded", init);
 
 async function init() {
@@ -132,6 +139,12 @@ function renderReleases(releases) {
 
         const isLatest = release.id === allReleases[0]?.id;
 
+        // Calculate total downloads for this release
+        const totalDownloads = release.assets.reduce(
+            (sum, asset) => sum + asset.download_count,
+            0,
+        );
+
         const card = document.createElement("div");
 
         card.className = `release-card ${isLatest ? "latest" : ""}`;
@@ -139,9 +152,21 @@ function renderReleases(releases) {
         card.innerHTML = `
             <div class="release-top">
                 <h3>${version}</h3>
-                <span class="tag ${type}">
-                    ${type}
-                </span>
+                <div class="release-top-meta">
+                    ${
+                        totalDownloads > 0
+                            ? `
+                        <span class="release-download-count" title="${totalDownloads.toLocaleString()} total downloads">
+                            <i class="fa-solid fa-download"></i>
+                            ${formatDownloadCount(totalDownloads)}
+                        </span>
+                    `
+                            : ""
+                    }
+                    <span class="tag ${type}">
+                        ${type}
+                    </span>
+                </div>
             </div>
 
             ${isLatest ? '<p class="release-date">Latest Release</p>' : ""}

--- a/index.html
+++ b/index.html
@@ -108,15 +108,18 @@
                 </div>
 
                 <div class="hero-actions">
-                    <a
-                        id="download-btn"
-                        href="#"
-                        class="btn btn-primary"
-                        style="pointer-events: none; opacity: 0.7"
-                    >
-                        <i class="fa-solid fa-spinner fa-spin"></i>
-                        Loading...
-                    </a>
+                    <div class="download-btn-wrapper">
+                        <a
+                            id="download-btn"
+                            href="#"
+                            class="btn btn-primary"
+                            style="pointer-events: none; opacity: 0.7"
+                        >
+                            <i class="fa-solid fa-spinner fa-spin"></i>
+                            Loading...
+                        </a>
+                        <span id="download-count" class="download-count-label" style="display: none;"></span>
+                    </div>
 
                     <a
                         href="https://discord.gg/kSSkYq7KAQ"

--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
 import { githubAPIFetch } from "./github-cache.js";
-
-function formatDownloadCount(num) {
-    if (num >= 1_000_000)
-        return (num / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
-    if (num >= 1_000) return (num / 1_000).toFixed(1).replace(/\.0$/, "") + "K";
-    return num.toLocaleString();
-}
+import { formatDownloadCount } from "./utils.js";
 
 async function loadLatestDownload() {
     try {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 import { githubAPIFetch } from "./github-cache.js";
 
+function formatDownloadCount(num) {
+    if (num >= 1_000_000)
+        return (num / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+    if (num >= 1_000) return (num / 1_000).toFixed(1).replace(/\.0$/, "") + "K";
+    return num.toLocaleString();
+}
+
 async function loadLatestDownload() {
     try {
         const data = await githubAPIFetch({
@@ -23,6 +30,19 @@ async function loadLatestDownload() {
             btn.innerHTML = `<i class="fa-solid fa-download"></i> Download Latest (${data.tag_name})`;
             btn.style.pointerEvents = "auto";
             btn.style.opacity = "1";
+        }
+
+        // Calculate total downloads across all assets of this release
+        const totalDownloads = data.assets.reduce(
+            (sum, asset) => sum + asset.download_count,
+            0,
+        );
+
+        if (totalDownloads > 0) {
+            const countEl = document.getElementById("download-count");
+
+            countEl.innerHTML = `<i class="fa-solid fa-arrow-down"></i> ${formatDownloadCount(totalDownloads)} downloads`;
+            countEl.style.display = "";
         }
     } catch (err) {
         console.error("Error loading latest release", err);

--- a/style.css
+++ b/style.css
@@ -604,9 +604,6 @@ footer {
 }
 
 .download-count-label {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
     font-size: 12px;
     opacity: 0.55;
     letter-spacing: 0.2px;
@@ -638,18 +635,13 @@ footer {
 }
 
 .release-download-count {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
     font-size: 12px;
     padding: 4px 10px;
     border-radius: 999px;
     background: rgba(90, 120, 255, 0.12);
     border: 1px solid rgba(90, 120, 255, 0.2);
     color: var(--accent-light);
-    font-weight: 600;
-    letter-spacing: 0.2px;
-    cursor: default;
+    letter-spacing: 0.5px;
     transition: background 0.2s ease;
 }
 

--- a/style.css
+++ b/style.css
@@ -74,6 +74,7 @@ main {
 .hero-actions {
     display: flex;
     justify-content: center;
+    align-items: flex-start;
     gap: 16px;
     margin-top: 12px;
     flex-wrap: wrap;
@@ -587,6 +588,78 @@ footer {
     50% {
         transform: translateY(-10px);
     }
+}
+
+/* ============================= */
+/* ===== DOWNLOAD STATS ===== */
+/* ============================= */
+
+/* --- Homepage: download count under button --- */
+
+.download-btn-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+}
+
+.download-count-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+    opacity: 0.55;
+    letter-spacing: 0.2px;
+    animation: fadeInUp 0.4s ease both;
+    animation-delay: 0.15s;
+}
+
+.download-count-label i {
+    font-size: 10px;
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* --- Download page: per-release count --- */
+
+.release-top-meta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.release-download-count {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(90, 120, 255, 0.12);
+    border: 1px solid rgba(90, 120, 255, 0.2);
+    color: var(--accent-light);
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    cursor: default;
+    transition: background 0.2s ease;
+}
+
+.release-download-count:hover {
+    background: rgba(90, 120, 255, 0.2);
+}
+
+.release-download-count i {
+    font-size: 10px;
+    opacity: 0.8;
 }
 
 /* ============================= */

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,7 @@
+export function formatDownloadCount(num) {
+    if (num >= 1_000_000)
+        return (num / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+    if (num >= 1_000)
+        return (num / 1_000).toFixed(1).replace(/\.0$/, "") + "K";
+    return num.toLocaleString();
+}


### PR DESCRIPTION
## What
Displays download counts fetched from the GitHub Releases API to build user trust.

- **Homepage**: Shows total downloads for the latest release as a subtle label below the download button.
- **Download page**: Each release card now displays a download count badge next to the release type tag.

## How
- Uses `download_count` from each release asset in the GitHub API response.
- Counts are summed across all assets per release.
- Large numbers are formatted for readability (e.g., 1.5K, 2M).
- No additional API calls — uses the existing `githubAPIFetch()` cache from `github-cache.js`.

## Files Changed
- `index.html` — Added download count label element under the download button.
- `index.js` — Added count calculation & display logic for latest release.
- `download.js` — Added per-release download count badge to release cards.
- `style.css` — Added styles for both homepage label & release card badges.

closes #29.