### PR TITLE
feat(community): handle contributor loading states

### DIFF
--- a/src/components/community/CommunityContent.tsx
+++ b/src/components/community/CommunityContent.tsx
@@ -4,6 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 import { SectionHeader } from "@/components/shared/SectionHeader";
 import { ContributorCard } from "@/components/community/ContributorCard";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { ButtonLink } from "@/components/ui/Button";
 import { getContributors, getRepoInfo } from "@/lib/github";
 import {
@@ -17,7 +19,12 @@ import { Star, GitFork, Users } from "lucide-react";
 type Display = ContributorProfile & { avatarUrl?: string };
 
 export function CommunityContent() {
-    const { data: contributors, isLoading } = useQuery({
+    const {
+        data: contributors,
+        isLoading,
+        error,
+        refetch,
+    } = useQuery({
         queryKey: ["github", "contributors"],
         queryFn: getContributors,
     });
@@ -102,6 +109,15 @@ export function CommunityContent() {
 
                 {isLoading ? (
                     <LoadingSpinner label="Loading contributors..." />
+                ) : error ? (
+                    <ErrorState
+                        message="We couldn't load the community contributors. Please try again."
+                        onRetry={() => {
+                            void refetch();
+                        }}
+                    />
+                ) : all.length === 0 ? (
+                    <EmptyState />
                 ) : (
                     <div className="community-container">
                         {all.map((c, i) => (

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,33 @@
+import { Users } from "lucide-react";
+
+interface EmptyStateProps {
+    title?: string;
+    message?: string;
+}
+
+export function EmptyState({
+    title = "No contributors found",
+    message = "There are no contributors to display right now.",
+}: EmptyStateProps) {
+    return (
+        <div
+            className="card mx-auto flex max-w-xl flex-col items-center gap-4 p-6 text-center"
+            role="status"
+        >
+            <Users
+                className="h-8 w-8 text-[var(--accent-light)]"
+                aria-hidden="true"
+            />
+
+            <div>
+                <h2 className="text-lg font-semibold text-[var(--text)]">
+                    {title}
+                </h2>
+
+                <p className="mt-1 text-sm text-[var(--text-muted)]">
+                    {message}
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ui/ErrorState.tsx
+++ b/src/components/ui/ErrorState.tsx
@@ -1,0 +1,41 @@
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+
+interface ErrorStateProps {
+    message?: string;
+    onRetry?: () => void;
+}
+
+export function ErrorState({
+    message = "Something went wrong while loading this content.",
+    onRetry,
+}: ErrorStateProps) {
+    return (
+        <div
+            className="card mx-auto flex max-w-xl flex-col items-center gap-4 p-6 text-center"
+            role="alert"
+        >
+            <AlertCircle
+                className="h-8 w-8 text-[var(--tag-alpha)]"
+                aria-hidden="true"
+            />
+
+            <div>
+                <h2 className="text-lg font-semibold text-[var(--text)]">
+                    Unable to load content
+                </h2>
+
+                <p className="mt-1 text-sm text-[var(--text-muted)]">
+                    {message}
+                </p>
+            </div>
+
+            {onRetry && (
+                <Button type="button" variant="secondary" onClick={onRetry}>
+                    <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                    Try again
+                </Button>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Improve the Community page's contributor loading experience by explicitly handling loading, error, empty, and successful states.

## Changes

- Added reusable `ErrorState` component with retry support.
- Added reusable `EmptyState` component for empty contributor results.
- Extended the contributor query to expose error and refetch state.
- Added an explicit error state with a retry action.
- Added an explicit empty state when the final contributor display list is empty.
- Preserved the existing contributor filtering, featured contributor handling, repository statistics, and contributor card rendering.

## State Handling

The contributor section now follows a clear rendering priority:

1. Loading
2. Error
3. Empty
4. Successful contributor grid

## Verification

- `npm run type-check` ✅
- `npm run lint` ✅
- `npm run format` ✅
- `npm run build` ✅
- Targeted Prettier check ✅
- `git diff --check` ✅