### PR TITLE
fix(download): avoid architecture fallback during detection

### DIFF
--- a/src/components/downloads/ArchDownload.tsx
+++ b/src/components/downloads/ArchDownload.tsx
@@ -26,7 +26,9 @@ export function ArchDownload({ assets, variant = "full", className }: Props) {
     const { arch: detected, isAndroid, isDetecting } = useArchDetection();
     const [open, setOpen] = useState(false);
 
-    const preferred: ArchKey = detected ?? "arm64";
+    const preferred: ArchKey = isDetecting
+        ? "universal"
+        : (detected ?? "arm64");
     const primary = pickRecommendedApk(assets, preferred);
     if (!primary) return null;
 

--- a/src/components/layout/PowerShortcuts.tsx
+++ b/src/components/layout/PowerShortcuts.tsx
@@ -8,6 +8,7 @@ import { useLatestRelease } from "@/hooks/useGithubRelease";
 import { useArchDetection } from "@/hooks/useArchDetection";
 import { pickRecommendedApk } from "@/lib/utils";
 import { DISCORD_URL } from "@/lib/constants";
+import type { ArchKey } from "@/types/arch";
 
 const LEADER = "p";
 const ARM_TIMEOUT = 1400;
@@ -26,7 +27,7 @@ function isTyping(el: EventTarget | null): boolean {
 
 export function PowerShortcuts() {
     const { data: latest } = useLatestRelease();
-    const { arch } = useArchDetection();
+    const { arch, isDetecting } = useArchDetection();
     const [armed, setArmed] = useState(false);
     const [helpOpen, setHelpOpen] = useState(false);
     const [toast, setToast] = useState<string | null>(null);
@@ -46,8 +47,11 @@ export function PowerShortcuts() {
     }, []);
 
     const downloadLatest = useCallback(() => {
+        const preferred: ArchKey = isDetecting
+            ? "universal"
+            : (arch ?? "arm64");
         const apk = latest
-            ? pickRecommendedApk(latest.assets, arch ?? "arm64")
+            ? pickRecommendedApk(latest.assets, preferred)
             : undefined;
         if (!apk) {
             flash("Release info still loading — try again in a sec.");
@@ -61,7 +65,7 @@ export function PowerShortcuts() {
         a.click();
         a.remove();
         flash(`Downloading ${apk.name}…`);
-    }, [latest, arch, flash]);
+    }, [latest, arch, isDetecting, flash]);
 
     const openDiscord = useCallback(
         () => window.open(DISCORD_URL, "_blank", "noopener"),


### PR DESCRIPTION
## Changes Made

- avoid explicitly defaulting to arm64 while architecture detection is in progress
- prefer the universal APK while device architecture detection is in progress
- make the keyboard download shortcuts (`P + D`, `P + Shift + D`) follow the same detection-aware selection logic
- preserve existing architecture-specific selection after detection completes
- preserve existing universal and fallback APK behavior

## Breaking Changes / Compatibility

No breaking changes.

This change prevents a premature architecture-specific recommendation while device detection is still in progress.

## Validation

- `npm run lint` — passed
- `npm run type-check` — passed
- `npm run build` — passed
- `git diff --check` — passed