### PR TITLE
fix(assets): resolve static asset paths on GitHub Pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+const basePath = process.env.BASE_PATH || '';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
@@ -5,8 +7,12 @@ const nextConfig = {
 
   // Set BASE_PATH=/Passcodes-Website only when building for GitHub Pages.
   // Local builds (npm run build / npm run dev) get '' → everything works at /.
-  basePath: process.env.BASE_PATH || '',
+  basePath,
   assetPrefix: process.env.ASSET_PREFIX || '',
+
+  env: {
+    BASE_PATH: basePath,
+  },
 
   images: {
     unoptimized: true,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,9 @@ export const metadata: Metadata = {
     title: { default: SITE_META.title, template: "%s | Passcodes" },
     description: SITE_META.description,
     metadataBase: new URL(SITE_META.url),
+    icons: {
+        icon: `${process.env.BASE_PATH || ""}/favicon.ico`,
+    },
     openGraph: {
         title: SITE_META.title,
         description: SITE_META.description,


### PR DESCRIPTION
## Changes Made

- expose the configured `BASE_PATH` to client-side code through Next.js build-time environment injection
- make logo and Komi Store badge URLs resolve correctly under the GitHub Pages project path
- explicitly configure the favicon using the deployment base path
- preserve the existing local development behavior when `BASE_PATH` is empty

## Breaking Changes / Compatibility

No breaking changes.

The change fixes static asset resolution for the GitHub Pages project deployment while preserving root-relative asset paths during local development.

## Validation

- `npm run build` — passed with GitHub Pages `BASE_PATH=/Passcodes-Website`
- `npm run build` — passed with local `BASE_PATH=""`
- verified generated logo, Komi Store badge, and favicon references
- `npm run lint` — passed
- `npm run type-check` — passed
- `git diff --check` — passed