### PR TITLE
refactor(releases): share release data across downloads

### DIFF
--- a/src/components/downloads/DownloadsContent.tsx
+++ b/src/components/downloads/DownloadsContent.tsx
@@ -8,9 +8,9 @@ import { DownloadCard } from "@/components/downloads/DownloadCard";
 import { ReleaseList } from "@/components/downloads/ReleaseList";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import {
-    useLatestRelease,
-    useAllReleases,
+    useReleases,
     isRateLimitError,
+    getLatestStableRelease,
 } from "@/hooks/useGithubRelease";
 import { KOMI_STORE_URL, KOMI_BADGE_SRC } from "@/lib/constants";
 import Link from "next/link";
@@ -57,21 +57,21 @@ function KomiSection() {
 
 export function DownloadsContent() {
     const {
-        data: latestRelease,
-        isLoading: isLoadingLatest,
-        error: latestError,
-    } = useLatestRelease();
-    const {
-        data: allReleases,
-        isLoading: isLoadingAll,
-        error: allError,
-    } = useAllReleases();
+        data: releases,
+        isLoading,
+        error,
+    } = useReleases();
     const [query, setQuery] = useState("");
     const [status, setStatus] = useState<Status>("all");
 
+    const latestRelease = useMemo(
+        () => (releases ? getLatestStableRelease(releases) : undefined),
+        [releases]
+    );
+
     const filtered = useMemo(() => {
         const q = query.trim().toLowerCase();
-        return (allReleases ?? []).filter((r) => {
+        return (releases ?? []).filter((r) => {
             const matchQ =
                 !q ||
                 (r.name || "").toLowerCase().includes(q) ||
@@ -82,11 +82,10 @@ export function DownloadsContent() {
                 (status === "prerelease" ? r.prerelease : !r.prerelease);
             return matchQ && matchS;
         });
-    }, [allReleases, query, status]);
+    }, [releases, query, status]);
 
-    const hasError = latestError || allError;
-    const isRateLimited =
-        isRateLimitError(latestError) || isRateLimitError(allError);
+    const hasError = !!error;
+    const isRateLimited = isRateLimitError(error);
     const hasControls = query.trim() !== "" || status !== "all";
 
     return (
@@ -126,7 +125,7 @@ export function DownloadsContent() {
                     </div>
                 )}
 
-                {isLoadingLatest ? (
+                {isLoading ? (
                     <LoadingSpinner label="Fetching latest release..." />
                 ) : (
                     latestRelease && (
@@ -211,7 +210,7 @@ export function DownloadsContent() {
                         </p>
                     )}
 
-                    {isLoadingAll ? (
+                    {isLoading ? (
                         <LoadingSpinner label="Loading releases..." />
                     ) : (
                         <ReleaseList releases={filtered} />

--- a/src/hooks/useGithubRelease.ts
+++ b/src/hooks/useGithubRelease.ts
@@ -1,26 +1,47 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getLatestRelease, getAllReleases, GithubRateLimitError } from '@/lib/github';
+import {
+  getAllReleases,
+  getLatestStableRelease,
+  GithubRateLimitError,
+} from '@/lib/github';
 import type { GithubRelease } from '@/types/github';
 
-/** Fetch the latest GitHub release with caching and error handling */
-export function useLatestRelease() {
-  return useQuery<GithubRelease, Error>({
-    queryKey: ['github', 'release', 'latest'],
-    queryFn: getLatestRelease,
+/** Fetch all releases with caching and error handling */
+export function useReleases() {
+  return useQuery<GithubRelease[], Error>({
+    queryKey: ['github', 'releases'],
+    queryFn: getAllReleases,
   });
 }
 
-/** Fetch all releases for download history */
+/** Fetch all releases for download history (alias for useReleases) */
 export function useAllReleases() {
-  return useQuery<GithubRelease[], Error>({
-    queryKey: ['github', 'releases', 'all'],
-    queryFn: getAllReleases,
-  });
+  return useReleases();
+}
+
+/**
+ * Fetch the latest stable release derived from the canonical releases query.
+ * Backward-compatible helper for consumers that only need the latest release.
+ */
+export function useLatestRelease() {
+  const query = useReleases();
+  const latestRelease = useMemo(
+    () => (query.data ? getLatestStableRelease(query.data) : undefined),
+    [query.data]
+  );
+
+  return {
+    ...query,
+    data: latestRelease,
+  };
 }
 
 /** Type guard to check if an error is a rate limit error */
 export function isRateLimitError(error: Error | null): boolean {
   return error instanceof GithubRateLimitError;
 }
+
+export { getLatestStableRelease };

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -72,6 +72,28 @@ export async function getRepoInfo(): Promise<GithubRepoInfo> {
 }
 
 /**
+ * Find the latest stable release from a list of releases.
+ * Follows GitHub's /releases/latest semantics:
+ * - not a draft
+ * - not a prerelease
+ * - newest according to created_at
+ * Pure function that does not mutate the source array.
+ */
+export function getLatestStableRelease(
+  releases: GithubRelease[]
+): GithubRelease | undefined {
+  return releases.reduce<GithubRelease | undefined>((latest, release) => {
+    if (release.draft || release.prerelease) return latest;
+    if (!latest) return release;
+
+    return new Date(release.created_at).getTime() >
+      new Date(latest.created_at).getTime()
+      ? release
+      : latest;
+  }, undefined);
+}
+
+/**
  * Calculate aggregated download statistics.
  */
 export async function getDownloadStats(): Promise<DownloadStats> {
@@ -85,7 +107,7 @@ export async function getDownloadStats(): Promise<DownloadStats> {
     return total + releaseDownloads;
   }, 0);
 
-  const latestRelease = releases[0];
+  const latestRelease = getLatestStableRelease(releases);
   const latestReleaseDownloads = latestRelease
     ? latestRelease.assets.reduce((sum, asset) => sum + asset.download_count, 0)
     : 0;


### PR DESCRIPTION
## Changes Made

- introduce a canonical React Query release collection shared across release consumers
- remove the separate `/releases/latest` request from the Downloads page
- derive the latest stable release from the canonical collection
- explicitly ignore draft and prerelease releases when determining latest
- select the latest release using `created_at` without mutating the release collection
- update download statistics to use the same latest-release semantics
- preserve the existing `useLatestRelease()` API for standalone consumers
- preserve existing Downloads UI, filtering, loading, error, and download behavior

## Breaking Changes / Compatibility

No breaking changes.

The release-data fetching flow has been consolidated internally. Existing consumers of `useLatestRelease()` continue to work while sharing the canonical release query.

## Validation

- `npm run lint` — passed
- `npm run type-check` — passed
- `npm run build` — passed (7/7 routes)
- `git diff --check` — passed
- latest stable-release edge cases verified
- release-array immutability verified
- live GitHub API result matched the derived latest stable release
- Downloads route verified
- Network request consolidation verified